### PR TITLE
Added support for extending HTMLElement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const buildHelper = template(`
             },
         });
         if (Object.setPrototypeOf){
-            Object.setPrototypeOf(ExtendableBuiltin, cls);
+            Object.setPrototypeOf(ExtendableBuiltin, cls, this.constructor);
         } else {
             ExtendableBuiltin.__proto__ = cls;
         }


### PR DESCRIPTION
Added a third parameter to Reflect.construct() which was preventing the plugin from working with classes that extend HTMLElement

I would like to contribute a test, but that would be a lot of work considering the tests do not currently support a browser environment. If someone wants to add that plumbing, they can use this test. It will have to be run in Chrome unless polyfills are provided. Not sure if Phantom supports it or not.

```js
    describe('HTMLElement', function(){
        class MyHTMLElement extends HTMLElement {
            constructor(){
                super();
                this.attr = null;
            }

            static get observedAttributes() {
                return [ 'supports' ]
            }

            attributeChangedCallback( name, oldValue, newValue ) {
                if (name === 'supports') {
                    this.attr = newValue;
                }
            }
        }

        it('should behave properly', function(){
            const a = new MyHTMLElement();
            a.setAttribute('supports', 'HTMLElement');

            expect(a instanceof MyHTMLElement).to.be.true;
            expect(a instanceof HTMLElement).to.be.true;

            expect(a).to.have.ownProperty('offsetLeft');
            expect(a).to.have.ownProperty('attr');

            expect(a.attr).to.eql('HTMLElement');
        });
    });
```