### PR TITLE
Improved setPrototypeOf reliability

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@ const buildHelper = template(`
         function ExtendableBuiltin(){
             // Not passing "newTarget" because core-js would fall back to non-exotic
             // object creation.
-            var instance = Reflect.construct(cls, Array.from(arguments));
-            Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+            var instance = Reflect.construct(cls, arguments);
+            HELPER.setPrototypeOf(instance, Object.getPrototypeOf(this));
             return instance;
         }
         ExtendableBuiltin.prototype = Object.create(cls.prototype, {
@@ -21,14 +21,10 @@ const buildHelper = template(`
                 configurable: true,
             },
         });
-        if (Object.setPrototypeOf){
-            Object.setPrototypeOf(ExtendableBuiltin, cls);
-        } else {
-            ExtendableBuiltin.__proto__ = cls;
-        }
-
+        HELPER.setPrototypeOf(ExtendableBuiltin, cls);
         return ExtendableBuiltin;
     }
+    HELPER.setPrototypeOf = Object.setPrototypeOf || function (o, p) { o.__proto__ = p; return o; };
 `);
 
 /**


### PR DESCRIPTION
This PR would like to fix the current behaviors for the **not approximate** version of the `HELPER`

  * ~~avoid trashing the already available `ExtendableBuiltin.prototype` with a not so useful assignment via `Object.create` since every function prototype already have a not enumerable constructor~~
  * ~~`setPrototypeOf` both function and its prototype~~
  * use a polyfilled `setPrototypeOf` also inside the constructor. Older browsers right now are checked for a `__proto__` fallback only at class definition and then fail each instance creation.
  * do not convert `arguments` into array. It's a redundant operation that is not needed. If leaks are the reason for that, passing them not via an `.apply` operation would leak anyway so here we had leak + duplicated info.

If last point is because `core.js` does something weird please let me know and I'll update this PR.

Thank you for considering this update.