### PR TITLE
Fix unrecognized super class if wrapped in parenthesis

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,11 @@ export default function({types: t}){
                 // Ensure the class is extending something.
                 const superClass = path.get('superClass');
                 if (!superClass.node) return;
+                
+                // Other plugins might wrap the super class in parenthesis
+                if (superClass.type === 'ParenthesizedExpression') {
+                  superClass = superClass.get('expression');
+                }
 
                 // Ensure that the class is extending a variable matching one of the options.
                 const matches = classes.some(name => superClass.isIdentifier({name}));


### PR DESCRIPTION
Right now this plugin doesn't work when another plugin like istanbul wraps the super class in parenthesis.
I added a small workaround to the the expression inside the parenthesis which makes this work again.