### PR TITLE
Fix JSON in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In your Babel 6 configuration, for example in a `.babelrc` you might have
 {
     "plugins": [
         ["babel-plugin-transform-builtin-extend", {
-            globals: ["Error", "Array"]
+            "globals": ["Error", "Array"]
         }]
     ]
 }
@@ -33,8 +33,8 @@ to approximate extending a class, though your results may vary depending on your
 {
     "plugins": [
         ["babel-plugin-transform-builtin-extend", {
-            globals: ["Error", "Array"],
-            approximate: true
+            "globals": ["Error", "Array"],
+            "approximate": true
         }]
     ]
 }


### PR DESCRIPTION
If you're doing any sort of `JSON.parse` of your babelrc file, these keys need quotes. Otherwise you run into something like:

```
undefined:24
            globals: ["Error"],
            ^

SyntaxError: Unexpected token g in JSON at position 591
    at JSON.parse (<anonymous>)
    at Object.<anonymous> (/path/file.js:38:26)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.wrappedLoad [as _load] (/path/node_modules/newrelic/lib/shimmer.js:344:38)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
```